### PR TITLE
Add tests for current gem functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Build output
 *.gem
+
+# Resolved gem dependency graphs are not checked into source control
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://www.rubygems.org"
+
+gemspec  

--- a/lib/reflect.rb
+++ b/lib/reflect.rb
@@ -2,8 +2,10 @@ $:.unshift(File.expand_path("../", __FILE__))
 
 require 'openssl'
 require 'base64'
+require 'json'
 
 require 'reflect/parameter'
+require 'reflect/version'
 
 module Reflect
   def self.generate_token(secret_key, parameters=[])
@@ -16,10 +18,16 @@ module Reflect
       JSON.generate([param.field, param.op, val, vals])
     end
 
+    hash_json(secret_key, data)
+  end
+
+
+  private
+  def self.hash_json(secret_key, json_data)
     digest = OpenSSL::Digest.new('sha256')
     hmac = OpenSSL::HMAC.new(secret_key, digest)
       .update("V2\n")
-      .update(data.sort.join("\n"))
+      .update(json_data.sort.join("\n"))
       .digest
 
     "=2=#{Base64.encode64(hmac).strip}"

--- a/test/reflect/token_test.rb
+++ b/test/reflect/token_test.rb
@@ -1,0 +1,26 @@
+require './test/test_helper'
+
+class TokenTest < Minitest::Test
+  extend Minitest::Spec::DSL
+
+  describe "token generation" do
+    let(:secret) { "muffin_assassin" }
+
+    it "generates a token with no parameters" do
+      expected = "=2=HDOT6E9fPju40km0WeQmGKW/ryNNPX529POBSdhr4lI=" 
+
+      assert_equal Reflect.generate_token(secret), expected
+    end
+
+    it "generates a token with parameters" do
+      parameters = [
+        Reflect::Parameter.new("field1", ">=", "abc"),
+        Reflect::Parameter.new("field2", "<", "123")
+      ]
+      expected = "=2=mYK0xsboM6he5NcV3fHg2IP39BYb6E7Tv4JVwBVUy58="
+
+      assert_equal Reflect.generate_token(secret, parameters), expected
+    end
+  end
+
+end

--- a/test/reflect/version_test.rb
+++ b/test/reflect/version_test.rb
@@ -1,0 +1,7 @@
+require "./test/test_helper"
+
+class ReflectVersionTest < Minitest::Test
+  def test_version
+    assert_equal Reflect::VERSION, "0.2.0"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require './lib/reflect'
+require 'minitest/autorun'


### PR DESCRIPTION
I spent just 30 minutes on this to introduce myself.  👋  Hi!

I don't know what the plan is for the ruby wrapper but if you are interested, I would:

- Start writing the wrapper around the API, there are quite a few ways to do this but once it got rolling it would turn into a tedious (positive inflection) task to cover the REST API.
- Add unit tests that would test outgoing messages.  This could be VCR or something else.
- Add `.env` and `dotenv` to use a real generated token to capture and update the recorded web requests.
- General refactoring.  I don't know if parameters are used as anything more than strings.  If reflect just has an API for creating parameter operations as sort of "future use" from within the dashboard then the existing class is basically fine.
- Add rake and bundler as dependencies (I didn't want to do this to your gem).

Running the tests:
```
$ bundle
$ rake test

...
Finished in 0.001679s, 1786.7779 runs/s, 1786.7779 assertions/s.

3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

Normally that'd be `bundle exec rake test`.  Easy change, just didn't want to add deps to the gemspec.